### PR TITLE
refactor: AbstractEntity & static create method

### DIFF
--- a/src/application/controllers/users/UserController.integration.test.ts
+++ b/src/application/controllers/users/UserController.integration.test.ts
@@ -55,7 +55,7 @@ describe('UserController Integration', () => {
 		const dto = new CreateUserDto(); // Value to change
 		dto.username = 'Initial'; // Value to change
 
-		const entity = UserEntity.create(dto); // Value to change
+		const entity = new UserEntity(dto); // Value to change
 		existingEntity = await repository.save(entity);
 	});
 
@@ -74,10 +74,10 @@ describe('UserController Integration', () => {
 
 	describe('CREATE', () => {
 		it('Can create an entity', async () => {
-			const response = UserResponseDto.fromEntity(UserEntity.create(createDto)); // Value to change
-			response.id = 2;
+			const created = (await controller.create(createDto)) as UserResponseDto;
+			expect(created.id).toEqual(2);
+			expect(created.username).toEqual(createDto.username);
 
-			await expect(controller.create(createDto)).resolves.toEqual(response);
 			await expect(wasLogged(TEST_NAME, `${className}: Creating a new entity`)).resolves.toBe(true);
 		});
 
@@ -97,15 +97,12 @@ describe('UserController Integration', () => {
 		// --------------------------------------------------
 
 		it('should fail with invalid data', async () => {
-			createDto.username = null; // Value to change
-			await expect(controller.create(createDto)).rejects.toThrow('UserEntity: validation error: "username" must be a string'); // Value to change
-		});
-
-		// --------------------------------------------------
-
-		it('should fail with invalid data', async () => {
-			createDto.username = '';
-			await expect(controller.create(createDto)).rejects.toThrow('UserEntity: validation error: "username" is not allowed to be empty'); // Value to change
+			const values: unknown[] = [null, undefined, '', 1, true, false, [], {}];
+			for (const value of values) {
+				// @ts-expect-error: Username expects a string.
+				createDto.username = value;
+				await expect(controller.create(createDto)).rejects.toThrow("UserEntity: Child's JSON schema validation failed"); // Value to change
+			}
 		});
 
 		// --------------------------------------------------

--- a/src/application/controllers/users/UserController.unit.test.ts
+++ b/src/application/controllers/users/UserController.unit.test.ts
@@ -9,6 +9,7 @@ import { UserResponseDto } from '../../../application/dtos/user/UserResponseDto'
 import { UserEntity } from '../../../domain/entities/user/UserEntity';
 import { GuardedController } from '../GuardedController';
 import { NewWinstonAdapter } from '../../../infrastructure/logging/adapters/NewWinstonAdapter';
+import { randomUUID } from 'crypto';
 
 describe('UserController Unit', () => {
 	let controller: GuardedController;
@@ -17,13 +18,15 @@ describe('UserController Unit', () => {
 	let expectedResponse: UserResponseDto; // Value to change
 
 	const ID = 1;
+	const UUID = randomUUID();
+	const CREATED_AT = Date.now();
 	const USERNAME = 'Bob';
 
 	beforeEach(async () => {
 		createDto = new CreateUserDto();
 		createDto.username = USERNAME;
 
-		expectedResponse = UserResponseDto.fromEntity(UserEntity.create({ id: ID, username: USERNAME }));
+		expectedResponse = UserResponseDto.fromEntity(new UserEntity({ id: ID, uuid: UUID, createdAt: CREATED_AT, username: USERNAME }));
 
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [UserController], // Value to change

--- a/src/application/dtos/ResponseDto.ts
+++ b/src/application/dtos/ResponseDto.ts
@@ -1,20 +1,41 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsPositive } from 'class-validator';
-import { AbstractEntity } from '../../domain/entities/AbstractEntity';
+import { IsNumber, IsPositive, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
+import { UUID } from 'crypto';
+import { AbstractEntity } from '../../domain/entities/AbstractEntity'; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 /**
- * This class is responsible for returning a {@link AbstractEntity} to the client.
+ * ResponseDto represents the standardized API response object for returning an {@link AbstractEntity} to the client.
  * It provides Swagger documentation for the API.
- * It JSON validates the following fields:
- * - id: number, positive number.
+ * It validates the following fields using a JSON schema:
+ * - id: Unique autoincremented numeric identifier of the entity.
+ * - uuid: A universally unique identifier of the entity.
+ * - createdAt: A positive number representing the creation timestamp in UNIX epoch format.
  */
 export class ResponseDto {
-	@ApiProperty({ description: 'Unique identifier of the entity', uniqueItems: true })
+	@ApiProperty({ description: 'Unique autoincrement identifier of the entity', example: 1, uniqueItems: true })
 	@IsNumber({}, { message: 'id must be a number' })
 	@IsPositive({ message: 'id must be a positive number' })
+	@Type(() => Number)
 	id: number;
+
+	@ApiProperty({ description: 'Universally unique identifier of the entity', example: '550e8400-e29b-41d4-a716-446655440000', uniqueItems: true })
+	@IsUUID('4', { message: 'uuid must be a valid UUID v4' })
+	uuid: UUID;
+
+	@ApiProperty({
+		description: 'Timestamp of when the entity was created using a UNIX timestamp',
+		example: 1711285967,
+		uniqueItems: true,
+	})
+	@IsNumber({}, { message: 'createdAt must be a number' })
+	@IsPositive({ message: 'createdAt must be a positive number' })
+	@Type(() => Number)
+	createdAt: number;
 
 	protected constructor(entity: AbstractEntity) {
 		this.id = entity.id;
+		this.uuid = entity.uuid;
+		this.createdAt = entity.createdAt;
 	}
 }

--- a/src/application/modules/users/UserModule.test.ts
+++ b/src/application/modules/users/UserModule.test.ts
@@ -17,6 +17,7 @@ describe(TEST_NAME, () => {
 	let repository: Repository<unknown>;
 
 	const ENDPOINT = '/v1/user'; // Value to change
+	const USERNAME = 'Initial'; // Value to change
 
 	beforeEach(async () => {
 		app = await createMockAppModule(UserModule); // Value to change
@@ -25,9 +26,9 @@ describe(TEST_NAME, () => {
 		repository = app.get(getRepositoryToken(UserEntity)); // Value to change
 
 		const dto = new CreateUserDto(); // Value to change
-		dto.username = 'Initial'; // Value to change
+		dto.username = USERNAME; // Value to change
 
-		const entity = UserEntity.create(dto); // Value to change
+		const entity = new UserEntity(dto); // Value to change
 		await repository.save(entity);
 	});
 
@@ -48,20 +49,20 @@ describe(TEST_NAME, () => {
 		const data = { username: 'Bob' }; // Value to change
 
 		it('Can create an entity', async () => {
-			const response = { id: 2, username: 'Bob' }; // Value to change
-
-			await request(app.getHttpServer())
+			const response = await request(app.getHttpServer())
 				.post(ENDPOINT)
 				.send(data)
 				.set('Cookie', [`jwt=${mockJwt}`])
-				.expect(201)
-				.expect(response);
+				.expect(201);
+
+			expect(response.body.id).toEqual(2);
+			expect(response.body.username).toEqual(data.username);
 
 			await expect(wasLogged(TEST_NAME, `UserController: Creating a new entity`)).resolves.toBe(true);
 			await expect(wasLogged(TEST_NAME, `UserService: Creating a new entity`)).resolves.toBe(true);
 
-			await expect(wasLogged(TEST_NAME, `UserSubscriber: Entity by id ${response.id} was inserted`)).resolves.toBe(true);
-			await expect(wasLogged(TEST_NAME, `UserService: Emitting entity by id: ${response.id}`)).resolves.toBe(true);
+			await expect(wasLogged(TEST_NAME, `UserSubscriber: Entity by id ${response.body.id} was inserted`)).resolves.toBe(true);
+			await expect(wasLogged(TEST_NAME, `UserService: Emitting entity by id: ${response.body.id}`)).resolves.toBe(true);
 		});
 
 		// --------------------------------------------------
@@ -83,7 +84,7 @@ describe(TEST_NAME, () => {
 		// --------------------------------------------------
 
 		it('Should return an error when inserting a duplicate entity', async () => {
-			data.username = 'Initial'; // Value to change
+			data.username = USERNAME; // Value to change
 
 			await request(app.getHttpServer())
 				.post(ENDPOINT)
@@ -107,13 +108,14 @@ describe(TEST_NAME, () => {
 
 	describe('GET /user', () => {
 		it('Finds all entities', async () => {
-			const response = [{ id: 1, username: 'Initial' }]; // Value to change
-
-			await request(app.getHttpServer())
+			const response = await request(app.getHttpServer())
 				.get(ENDPOINT)
 				.set('Cookie', [`jwt=${mockJwt}`])
-				.expect(200)
-				.expect(response);
+				.expect(200);
+
+			expect(response.body.length).toBeGreaterThanOrEqual(1);
+			expect(response.body[0].id).toEqual(1);
+			expect(response.body[0].username).toEqual(USERNAME);
 
 			await expect(wasLogged(TEST_NAME, `UserController: Finding all entities`)).resolves.toBe(true);
 			await expect(wasLogged(TEST_NAME, `UserService: Finding all entities`)).resolves.toBe(true);
@@ -138,14 +140,16 @@ describe(TEST_NAME, () => {
 	// -------------------------------------------------- \\
 
 	describe('GET /user/:id', () => {
-		const expected = { id: 1, username: 'Initial' }; // Value to change
+		const expected = { id: 1, username: USERNAME }; // Value to change
 
 		it('Can find an entity by id', async () => {
-			await request(app.getHttpServer())
+			const response = await request(app.getHttpServer())
 				.get(`${ENDPOINT}/${expected.id}`)
 				.set('Cookie', [`jwt=${mockJwt}`])
-				.expect(200)
-				.expect(expected);
+				.expect(200);
+
+			expect(response.body.id).toEqual(expected.id);
+			expect(response.body.username).toEqual(expected.username);
 
 			await expect(wasLogged(TEST_NAME, `UserController: Finding entity by id ${expected.id}`)).resolves.toBe(true);
 			await expect(wasLogged(TEST_NAME, `UserService: Finding entity by id ${expected.id}`)).resolves.toBe(true);
@@ -192,12 +196,14 @@ describe(TEST_NAME, () => {
 		const expected = { id: 1, username: 'Bob' }; // Value to change
 
 		it('Can update an entity', async () => {
-			await request(app.getHttpServer())
+			const response = await request(app.getHttpServer())
 				.patch(`${ENDPOINT}/${expected.id}`)
 				.send(data)
 				.set('Cookie', [`jwt=${mockJwt}`])
-				.expect(200)
-				.expect(expected);
+				.expect(200);
+
+			expect(response.body.id).toEqual(expected.id);
+			expect(response.body.username).toEqual(expected.username);
 
 			await expect(wasLogged(TEST_NAME, `UserController: Updating entity by id ${expected.id}`)).resolves.toBe(true);
 			await expect(wasLogged(TEST_NAME, `UserService: Updating entity by id ${expected.id}`)).resolves.toBe(true);

--- a/src/application/services/user/UserService.integration.test.ts
+++ b/src/application/services/user/UserService.integration.test.ts
@@ -13,6 +13,7 @@ import { UserService } from './UserService';
 import { wasLogged } from '../../../__tests__/helpers/wasLogged';
 import { AbstractService } from '../AbstractService';
 import { ISseMessage } from '../../../application/events/ISseMessage';
+import { randomUUID } from 'crypto';
 
 // Value to change
 describe('UserService Integration', () => {
@@ -20,6 +21,8 @@ describe('UserService Integration', () => {
 	process.env.TEST_NAME = testName; // Creates a log file named with this test's name.
 
 	const ID = 1;
+	const UUID = randomUUID();
+	const CREATED_AT = Date.now();
 	const USERNAME = 'test';
 
 	let service: AbstractService<CreateUserDto, UpdateUserDto, UserResponseDto>; // Values to change
@@ -70,10 +73,11 @@ describe('UserService Integration', () => {
 		const response = await service.findAll();
 
 		expect(response).toBeInstanceOf(Array);
-		expect(response).toContainEqual({ id: ID, username: USERNAME });
 
 		for (const entity of response) {
 			expect(entity).toBeInstanceOf(UserResponseDto);
+			expect(entity.id).toEqual(ID);
+			expect(entity.username).toEqual(USERNAME);
 		}
 
 		await expect(wasLogged(testName, `${className}: Finding all entities`)).resolves.toBe(true);
@@ -139,7 +143,7 @@ describe('UserService Integration', () => {
 		const events = service['events'] as Subject<ISseMessage<UserResponseDto>>;
 		const spy = jest.spyOn(events, 'next');
 
-		const data = UserEntity.create({ id: ID, username: USERNAME });
+		const data = new UserEntity({ id: ID, uuid: UUID, createdAt: CREATED_AT, username: USERNAME });
 		service.emit(data);
 
 		expect(spy).toHaveBeenCalledWith({ data: UserResponseDto.fromEntity(data) });

--- a/src/application/services/user/UserService.ts
+++ b/src/application/services/user/UserService.ts
@@ -29,7 +29,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 		this.logger.info(`Creating a new entity`);
 
 		const transaction = await this.entityManager.transaction(async (entityManager: EntityManager) => {
-			const entity = UserEntity.create(createDto);
+			const entity = new UserEntity(createDto);
 
 			return entityManager.save(entity);
 		});
@@ -44,7 +44,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 		this.logger.info(`Finding all entities`);
 
 		const data = await this.repository.find();
-		const entities = data.map((entity) => UserEntity.create(entity)); // Validate the data
+		const entities = data.map((entity) => new UserEntity(entity)); // Validate the data
 
 		return entities.map((entity) => UserResponseDto.fromEntity(entity));
 	}
@@ -58,7 +58,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 		const data = await this.repository.findOneBy({ id });
 
 		if (!data) throw new NotFoundException(`Entity by id ${id} not found`);
-		const entity = UserEntity.create(data); // Validate the data
+		const entity = new UserEntity(data); // Validate the data
 
 		return UserResponseDto.fromEntity(entity);
 	}
@@ -73,7 +73,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 			const data = await this.repository.findOneBy({ id });
 			if (!data) throw new NotFoundException(`Entity by id ${id} not found`);
 
-			const entity = UserEntity.create(data); // Validate the data
+			const entity = new UserEntity(data); // Validate the data
 			entity.update(updateDto);
 
 			return entityManager.save(entity);
@@ -108,7 +108,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 	public emit(data: UserEntity) {
 		this.logger.info(`Emitting entity by id: ${data.id}`);
 
-		const entity = UserEntity.create(data); // Validate the data
+		const entity = new UserEntity(data); // Validate the data
 		this.events.next({ data: UserResponseDto.fromEntity(entity) });
 	}
 }

--- a/src/application/services/user/UserService.unit.test.ts
+++ b/src/application/services/user/UserService.unit.test.ts
@@ -13,16 +13,19 @@ import { UpdateUserDto } from '../../../application/dtos/user/UpdateUserDto';
 import { ISseMessage } from '../../../application/events/ISseMessage';
 import { AbstractService } from '../AbstractService';
 import { NewWinstonAdapter } from '../../../infrastructure/logging/adapters/NewWinstonAdapter';
+import { randomUUID } from 'crypto';
 
 describe('UserService Unit', () => {
 	const ID = 1;
+	const UUID = randomUUID();
+	const CREATED_AT = Date.now();
 	const USERNAME = 'test';
 
 	let entity: UserEntity;
 	let service: AbstractService<CreateUserDto, UpdateUserDto, UserResponseDto>;
 
 	beforeEach(async () => {
-		entity = UserEntity.create({ id: ID, username: USERNAME });
+		entity = new UserEntity({ id: ID, uuid: UUID, createdAt: CREATED_AT, username: USERNAME });
 
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
@@ -58,8 +61,6 @@ describe('UserService Unit', () => {
 		dto.username = USERNAME;
 
 		const created = await service.create(dto);
-		expect(created).toEqual(entity);
-
 		expect(created).toBeInstanceOf(UserResponseDto);
 		expect(created.id).toEqual(ID);
 		expect(created.username).toEqual(USERNAME);
@@ -148,7 +149,7 @@ describe('UserService Unit', () => {
 		const events = service['events'] as Subject<ISseMessage<UserResponseDto>>;
 		const spy = jest.spyOn(events, 'next');
 
-		const data = UserEntity.create({ id: ID, username: USERNAME });
+		const data = new UserEntity({ id: ID, uuid: UUID, createdAt: CREATED_AT, username: USERNAME });
 		service.emit(data);
 
 		expect(spy).toHaveBeenCalledWith({ data: UserResponseDto.fromEntity(data) });

--- a/src/domain/entities/AbstractEntity.test.ts
+++ b/src/domain/entities/AbstractEntity.test.ts
@@ -1,0 +1,108 @@
+import Joi from 'joi';
+import { AbstractEntity } from './AbstractEntity';
+import { randomUUID } from 'crypto';
+
+/**
+ * Mock Entity to test the {@link AbstractEntity}'s functionality.
+ * @extends AbstractEntity
+ */
+class MockEntity extends AbstractEntity {
+	username: string;
+
+	constructor(entity: Partial<MockEntity>) {
+		super(entity);
+
+		if (entity) this.username = entity.username;
+	}
+
+	/**
+	 *
+	 */
+	public update(entity: Partial<MockEntity>): MockEntity {
+		if (entity.username) this.username = entity.username;
+
+		this.validate(this);
+		return this;
+	}
+
+	/* Getters & Setters */
+
+	protected get childSchema() {
+		return Joi.object({
+			username: Joi.string().min(3).required(),
+		});
+	}
+}
+
+describe('AbstractEntity', () => {
+	const ID = 1;
+	const UUID = randomUUID();
+	const CREATED_AT = Date.now();
+	const USERNAME = 'John Doe';
+
+	describe('Happy flow', () => {
+		it('Can create and validate children using a static factory with maximal values', () => {
+			const entity = new MockEntity({ id: ID, uuid: UUID, createdAt: CREATED_AT, username: USERNAME });
+
+			expect(entity).toBeInstanceOf(MockEntity);
+			expect(entity.id).toEqual(ID);
+			expect(entity.uuid).toEqual(UUID);
+			expect(entity.createdAt).toEqual(CREATED_AT);
+			expect(entity.username).toEqual(USERNAME);
+		});
+
+		// --------------------------------------------------
+
+		it('Can create and validate children using a static factory with minimal values', () => {
+			const entity = new MockEntity({ username: USERNAME });
+
+			expect(entity).toBeInstanceOf(MockEntity);
+
+			expect(entity.id).toBeUndefined();
+
+			expect(entity.uuid).toBeTruthy();
+			expect(typeof entity.uuid).toBe('string');
+
+			expect(entity.createdAt).toBeTruthy();
+			expect(typeof entity.createdAt).toBe('number');
+
+			expect(entity.username).toEqual(USERNAME);
+		});
+
+		// --------------------------------------------------
+
+		it('Allows children to update their values', () => {
+			const UPDATED_VALUE = 'Jane Doe';
+
+			const maximalEntity = new MockEntity({ id: ID, uuid: UUID, createdAt: CREATED_AT, username: USERNAME });
+			maximalEntity.update({ username: UPDATED_VALUE });
+
+			expect(maximalEntity).toBeInstanceOf(MockEntity);
+			expect(maximalEntity.username).toEqual(UPDATED_VALUE);
+
+			// ---
+
+			const minimalEntity = new MockEntity({ username: USERNAME });
+			minimalEntity.update({ username: UPDATED_VALUE });
+
+			expect(minimalEntity).toBeInstanceOf(MockEntity);
+			expect(minimalEntity.username).toEqual(UPDATED_VALUE);
+		});
+	});
+
+	// --------------------------------------------------
+
+	describe('Errors', () => {
+		it('Throws for unexpected values', () => {
+			// @ts-expect-error: Create method / constructor don't accept unknown values
+			expect(() => new MockEntity({ malicious: USERNAME, injection: 'SELECT *' })).toThrow('Disallowed keys: malicious, injection');
+		});
+
+		// --------------------------------------------------
+
+		it("Throws when the parent's schema fails", () => {
+			// @ts-expect-error: ID value must be a number
+			expect(() => new MockEntity({ id: 'YOLO' })).toThrow('JSON schema validation failed: "id" must be a number');
+		});
+	});
+});

--- a/src/domain/entities/AbstractEntity.ts
+++ b/src/domain/entities/AbstractEntity.ts
@@ -1,31 +1,114 @@
-import { PrimaryGeneratedColumn } from 'typeorm';
+import { randomUUID, UUID } from 'crypto';
+import Joi from 'joi';
+import { Column, PrimaryGeneratedColumn } from 'typeorm';
 
 /**
  * This abstract class represents any entity in the database.
- * It provides a unique auto-generated identifier and enforced validation.
+ * It provides a few base values and automatic self-validation using a JSON schema upon creation.
  * @column id INTEGER PRIMARY KEY AUTOINCREMENT
+ * @column uuid TEXT NOT NULL UNIQUE
+ * @column createdAt INTEGER NOT NULL
  */
 export abstract class AbstractEntity {
 	@PrimaryGeneratedColumn()
 	id: number;
 
+	@Column({ type: 'uuid', nullable: false, unique: true })
+	uuid: UUID;
+
+	@Column({ name: 'created_at', nullable: false })
+	createdAt: number;
+
 	protected constructor(entity: Partial<AbstractEntity>) {
 		if (entity) {
-			this.validate(entity); // Validate the children.
-
+			// When adding new values to this AbstractEntity, remember to add it to the parentSchema below.
 			this.id = entity.id;
+			this.uuid = entity.uuid ?? randomUUID();
+			this.createdAt = entity.createdAt ?? Date.now();
+
+			this.validate(entity); // Validate the children.
 		}
 	}
 
 	/**
 	 * Updates the entity with the provided data.
 	 * @param entity The data to update the entity with.
+	 * @devnote !!! REMEMBER TO CALL this.validate at the end of the function !!!
 	 */
 	protected abstract update(entity: Partial<AbstractEntity>): AbstractEntity;
 
 	/**
-	 * Enforced JSON validation, executed by the parent.
-	 * @param entity The entity to validate.
+	 * Performs a JSON schema validation for the parent's base values and the child's own values.
+	 * @throws ValidationError if either the parent or the child's JSON schemas fail.
+	 * @devnote This needs to be manually implemented in the child's `update` function.
 	 */
-	protected abstract validate(entity: Partial<AbstractEntity>): void;
+	protected validate(entity: Partial<AbstractEntity>): void {
+		this.validateParent();
+		this.validateChild(entity);
+	}
+
+	/**
+	 * Execute a JSON schema validation for the parent's schema.
+	 * @devnote Check the {@link parentSchema} getter for more info.
+	 */
+	private validateParent(): void {
+		const { error } = this.parentSchema.strict().validate(this, { abortEarly: false, allowUnknown: true });
+		if (error) throw new Error(`${this.constructor.name}: Parent's JSON schema validation failed: ${this.generateJsonSchemaErrorMessage(error)}`);
+	}
+
+	/**
+	 * Execute a JSON schema validation on the child's incoming data.
+	 * @param entity The child's incoming data to validate.
+	 * @devnote Check the {@link childSchema} getter for more info.
+	 */
+	private validateChild(entity: Partial<AbstractEntity>): void {
+		const { error } = Joi.alternatives() // Allow either a full parent+child schema or a child-only schema.
+			.try(this.parentSchema.concat(this.childSchema), this.childSchema)
+			.strict()
+			.validate(entity, { abortEarly: false, allowUnknown: false });
+
+		if (error) throw new Error(`${this.constructor.name}: Child's JSON schema validation failed: ${this.generateJsonSchemaErrorMessage(error)}`);
+	}
+
+	/**
+	 * Generate a detailed error message from a Joi ValidationError.
+	 * @param error The Joi ValidationError to generate a message from.
+	 */
+	private generateJsonSchemaErrorMessage(error: Joi.ValidationError): string {
+		let message = error.message;
+
+		const disallowedKeys: string[] = [];
+		if (error.details) {
+			for (const detail of error.details) {
+				const value = detail.context?.value;
+
+				if (detail.context && value && typeof value === 'object') {
+					const keys = Object.keys(value);
+					disallowedKeys.push(...keys);
+				}
+			}
+		}
+
+		if (disallowedKeys.length >= 1) message += ` - Disallowed keys: ${disallowedKeys.join(', ')}`;
+		return message;
+	}
+
+	/* Getters & Setters */
+
+	/**
+	 * The child's JSON schema.
+	 * This only needs to include the child's own values. Inherited values can be skipped.
+	 */
+	protected abstract get childSchema(): Joi.ObjectSchema;
+
+	/**
+	 * The parent's JSON schema.
+	 */
+	private get parentSchema(): Joi.ObjectSchema {
+		return Joi.object({
+			id: Joi.number().integer().positive().optional(), // Optional since a new entity might not have an ID yet.
+			uuid: Joi.string().uuid({ version: 'uuidv4' }).required(),
+			createdAt: Joi.number().integer().positive().required(),
+		});
+	}
 }

--- a/src/domain/entities/AbstractEntity.ts
+++ b/src/domain/entities/AbstractEntity.ts
@@ -7,7 +7,7 @@ import { Column, PrimaryGeneratedColumn } from 'typeorm';
  * It provides a few base values and automatic self-validation using a JSON schema upon creation.
  * @column id INTEGER PRIMARY KEY AUTOINCREMENT
  * @column uuid TEXT NOT NULL UNIQUE
- * @column createdAt INTEGER NOT NULL
+ * @column created_at INTEGER NOT NULL
  */
 export abstract class AbstractEntity {
 	@PrimaryGeneratedColumn()
@@ -33,7 +33,7 @@ export abstract class AbstractEntity {
 	/**
 	 * Updates the entity with the provided data.
 	 * @param entity The data to update the entity with.
-	 * @devnote !!! REMEMBER TO CALL this.validate at the end of the function !!!
+	 * @devnote !!! REMEMBER TO CALL **this.validate(this)** at the end of the function !!!
 	 */
 	protected abstract update(entity: Partial<AbstractEntity>): AbstractEntity;
 
@@ -89,15 +89,16 @@ export abstract class AbstractEntity {
 			}
 		}
 
-		if (disallowedKeys.length >= 1) message += ` - Disallowed keys: ${disallowedKeys.join(', ')}`;
+		if (disallowedKeys.length >= 1) message += ` - Problematic keys: ${disallowedKeys.join(', ')}`;
 		return message;
 	}
 
 	/* Getters & Setters */
 
 	/**
-	 * The child's JSON schema.
-	 * This only needs to include the child's own values. Inherited values can be skipped.
+	 * The child's JSON schema which will be used for auto-validation.
+	 * This only needs to include the child's own values.
+	 * Inherited values can be skipped.
 	 */
 	protected abstract get childSchema(): Joi.ObjectSchema;
 

--- a/src/domain/entities/user/UserEntity.test.ts
+++ b/src/domain/entities/user/UserEntity.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { CreateUserDto } from '../../../application/dtos/user/CreateUserDto';
 import { UpdateUserDto } from '../../../application/dtos/user/UpdateUserDto';
 import { UserResponseDto } from '../../../application/dtos/user/UserResponseDto';
@@ -5,15 +6,19 @@ import { UserEntity } from './UserEntity';
 
 describe('UserEntity and its DTOs', () => {
 	const ID = 1;
+	const UUID = randomUUID();
+	const CREATED_AT = Date.now();
 	const USERNAME = 'test';
 
 	// --------------------------------------------------
 
 	it('Can create itself', () => {
-		const entity = UserEntity.create({ id: ID, username: USERNAME });
+		const entity = new UserEntity({ username: USERNAME });
 
 		expect(entity).toBeInstanceOf(UserEntity);
-		expect(entity.id).toEqual(ID);
+		expect(entity.id).toBeUndefined();
+		expect(entity.uuid).toBeTruthy();
+		expect(entity.createdAt).toBeTruthy();
 		expect(entity.username).toEqual(USERNAME);
 	});
 
@@ -23,9 +28,12 @@ describe('UserEntity and its DTOs', () => {
 		const createDto = new CreateUserDto();
 		createDto.username = USERNAME;
 
-		const entity = UserEntity.create(createDto);
+		const entity = new UserEntity(createDto);
 
 		expect(entity).toBeInstanceOf(UserEntity);
+		expect(entity.id).toBeUndefined();
+		expect(entity.uuid).toBeTruthy();
+		expect(entity.createdAt).toBeTruthy();
 		expect(entity.username).toEqual(USERNAME);
 	});
 
@@ -35,20 +43,25 @@ describe('UserEntity and its DTOs', () => {
 		const updateDto = new UpdateUserDto();
 		updateDto.username = USERNAME;
 
-		const entity = UserEntity.create(updateDto);
-
-		expect(entity).toBeInstanceOf(UserEntity);
+		const entity = new UserEntity(updateDto);
 		expect(entity.username).toEqual(USERNAME);
+
+		entity.username = '123';
+
+		const updated = entity.update(updateDto);
+		expect(updated.username).toEqual(USERNAME);
 	});
 
 	// --------------------------------------------------
 
 	it('Can create a User Response DTO', () => {
-		const entity = UserEntity.create({ id: 1, username: 'test' });
+		const entity = new UserEntity({ id: ID, uuid: UUID, createdAt: CREATED_AT, username: USERNAME });
 		const dto = UserResponseDto.fromEntity(entity);
 
 		expect(dto).toBeInstanceOf(UserResponseDto);
 		expect(dto.id).toEqual(ID);
+		expect(dto.uuid).toEqual(UUID);
+		expect(dto.createdAt).toEqual(CREATED_AT);
 		expect(dto.username).toEqual(USERNAME);
 	});
 });

--- a/src/domain/entities/user/UserEntity.ts
+++ b/src/domain/entities/user/UserEntity.ts
@@ -11,7 +11,7 @@ export class UserEntity extends AbstractEntity {
 	@Column({ unique: true, nullable: false })
 	username: string;
 
-	protected constructor(entity: Partial<UserEntity>) {
+	constructor(entity: Partial<UserEntity>) {
 		super(entity);
 
 		if (entity) {
@@ -20,32 +20,19 @@ export class UserEntity extends AbstractEntity {
 	}
 
 	/**
-	 * Factory method to create a new UserEntity.
 	 */
-	static create(entity: Partial<UserEntity>): UserEntity {
-		return new UserEntity(entity);
-	}
+	public update(entity: Partial<UserEntity>) {
+		if (entity.username) this.username = entity.username;
 
-	/**
-	 */
-	public update(entity: Partial<UserEntity>): UserEntity {
-		this.validate(entity);
-		this.username = entity.username;
-
+		this.validate(this);
 		return this;
 	}
 
-	/**
-	 *
-	 */
-	protected validate(entity: Partial<UserEntity>): void {
-		const { error } = Joi.object({
-			id: Joi.number().positive(), // ID value is provided by the parent class.
-			username: Joi.string().min(3).required(),
-		})
-			.required()
-			.validate(entity);
+	/* Getters & Setters */
 
-		if (error) throw new Error(`${this.constructor.name}: validation error: ${error.message}`);
+	protected get childSchema() {
+		return Joi.object({
+			username: Joi.string().min(3).required(),
+		});
 	}
 }


### PR DESCRIPTION
Refactored the AbstractEntity. It now automatically validates its own (parent) JSON schema as well as its child's JSON schema.
It now includes the following default values:
- uuid
- createdAt

Added the same values with documentation to ResponseDto.

Refactored tests to abide by these new rules.  
Refactored User Service to no longer use a static 'create' method for UserEntities.  
Factory method will have to be self-implemented using a manager for complex entities.