### PR TITLE
Refactor/general updates

### DIFF
--- a/config/development/log_config.json
+++ b/config/development/log_config.json
@@ -14,6 +14,7 @@
     "http": {
         "enabled": false
     },
+    "database": false,
     "useWhitelist": false,
     "prefixWhitelist": []
 }

--- a/config/testing/log_config.json
+++ b/config/testing/log_config.json
@@ -14,6 +14,7 @@
     "http": {
         "enabled": false
     },
+    "database": false,
     "useWhitelist": false,
     "prefixWhitelist": []
 }

--- a/src/__tests__/helpers/falsyValues.ts
+++ b/src/__tests__/helpers/falsyValues.ts
@@ -1,0 +1,22 @@
+/**
+ * Construct an array of JavaScript considered 'falsy' values.
+ * Optionally add strings of certain lengths for validation purposes.
+ * Optionally remove the 'null' and 'undefined' values for validating optional values.
+ * @param min Add a string with a minimum length requirement.
+ * @param max Add a string with a maximum length requirement.
+ * @param noNullOrUndefined Remove 'null' and 'undefined'. Defaults to false.
+ * @returns An array of unkown 'falsy' values.
+ */
+export const falsyValues = (min?: number, max?: number, noNullOrUndefined: boolean = false): unknown[] => {
+	const values = ['', 0, -100, true, false, [], {}, Symbol('')];
+
+	if (min) values.push('a'.repeat(min - 1));
+	if (max) values.push('b'.repeat(max + 1));
+
+	if (!noNullOrUndefined) {
+		values.push(null);
+		values.push(undefined);
+	}
+
+	return values;
+};

--- a/src/__tests__/mocks/dto/MockUserDto.ts
+++ b/src/__tests__/mocks/dto/MockUserDto.ts
@@ -1,5 +1,5 @@
-import { CreateUserDto } from '../../http_api/dtos/user/CreateUserDto';
-import { UpdateUserDto } from '../../http_api/dtos/user/UpdateUserDto';
+import { CreateUserDto } from '../../../http_api/dtos/user/CreateUserDto';
+import { UpdateUserDto } from '../../../http_api/dtos/user/UpdateUserDto';
 
 /**
  * A Mock {@link CreateUserDto} for testing purposes.

--- a/src/__tests__/mocks/repository/MockRepository.ts
+++ b/src/__tests__/mocks/repository/MockRepository.ts
@@ -14,6 +14,12 @@ type TFindOneQuery = {
 export class MockRepository<Entity extends AbstractEntity> {
 	constructor(private createEntity: () => Entity) {}
 
+	count = jest.fn().mockResolvedValue(0);
+
+	save = jest.fn().mockResolvedValue((data: unknown) => {
+		return data;
+	});
+
 	find = jest.fn().mockResolvedValue([this.createEntity()]);
 
 	findOne = jest.fn().mockImplementation((query: TFindOneQuery) => {

--- a/src/application/services/AbstractService.ts
+++ b/src/application/services/AbstractService.ts
@@ -15,7 +15,6 @@ import { WinstonAdapter } from '../../infrastructure/logging/adapters/WinstonAda
  */
 @Injectable()
 export class AbstractService<CDTO extends CreateDto, UDTO extends UpdateDto, RDTO extends ResponseDto> implements OnModuleInit {
-	private _seedRequirement = false;
 	protected logger: ILogger;
 	protected readonly events = new Subject<ISseMessage<RDTO>>();
 

--- a/src/application/services/user/UserService.integration.test.ts
+++ b/src/application/services/user/UserService.integration.test.ts
@@ -11,7 +11,7 @@ import { AbstractService } from '../AbstractService';
 import { ISseMessage } from '../../../application/events/ISseMessage';
 import { createMockAppModule } from '../../../__tests__/mocks/module/createMockAppModule';
 import { UserModule } from '../../../http_api/modules/users/UserModule';
-import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/dto/MockUserDto';
+import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/mocks/dto/MockUserDto';
 import { MockUserEntity } from '../../../__tests__/mocks/entity/MockUserEntity';
 
 // Value to change
@@ -144,12 +144,12 @@ describe('UserService Integration', () => {
 	// --------------------------------------------------
 
 	it('Can emit events', async () => {
-		const events = service['events'] as Subject<ISseMessage<UserResponseDto>>;
+		const events = service['events'];
 		const spy = jest.spyOn(events, 'next');
 
-		service.emit(entity);
+		await service.emit(entity);
 
-		expect(spy).toHaveBeenCalledWith({ data: UserResponseDto.fromEntity(entity) });
+		expect(spy).toHaveBeenCalledWith({ data: UserResponseDto.create(entity) });
 		await expect(wasLogged(testName, `${className}: Emitting entity by id: ${entity.id}`)).resolves.toBe(true);
 	});
 });

--- a/src/application/services/user/UserService.integration.test.ts
+++ b/src/application/services/user/UserService.integration.test.ts
@@ -1,5 +1,4 @@
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Subject } from 'rxjs';
 import { Repository } from 'typeorm';
 import { CreateUserDto } from '../../../http_api/dtos/user/CreateUserDto';
 import { UpdateUserDto } from '../../../http_api/dtos/user/UpdateUserDto';
@@ -8,7 +7,6 @@ import { UserEntity } from '../../../domain/user/UserEntity';
 import { UserService } from './UserService';
 import { wasLogged } from '../../../__tests__/helpers/wasLogged';
 import { AbstractService } from '../AbstractService';
-import { ISseMessage } from '../../../application/events/ISseMessage';
 import { createMockAppModule } from '../../../__tests__/mocks/module/createMockAppModule';
 import { UserModule } from '../../../http_api/modules/users/UserModule';
 import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/mocks/dto/MockUserDto';

--- a/src/application/services/user/UserService.ts
+++ b/src/application/services/user/UserService.ts
@@ -34,7 +34,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 			return entityManager.save(entity);
 		});
 
-		return UserResponseDto.fromEntity(transaction);
+		return UserResponseDto.create(transaction);
 	}
 
 	/**
@@ -46,7 +46,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 		const data = await this.repository.find();
 		const entities = data.map((entity) => UserEntity.create(entity)); // Validate the data
 
-		return entities.map((entity) => UserResponseDto.fromEntity(entity));
+		return entities.map((entity) => UserResponseDto.create(entity));
 	}
 
 	/**
@@ -60,7 +60,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 		if (!data) throw new NotFoundException(`Entity by id ${id} not found`);
 		const entity = UserEntity.create(data); // Validate the data
 
-		return UserResponseDto.fromEntity(entity);
+		return UserResponseDto.create(entity);
 	}
 
 	/**
@@ -79,7 +79,7 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 			return entityManager.save(entity);
 		});
 
-		return UserResponseDto.fromEntity(transaction);
+		return UserResponseDto.create(transaction);
 	}
 
 	/**
@@ -108,8 +108,12 @@ export class UserService extends AbstractService<CreateUserDto, UpdateUserDto, U
 	public async emit(data: UserEntity) {
 		this.logger.info(`Emitting entity by id: ${data.id}`);
 
-		const entity = UserEntity.create(data); // Validate the data
-		this.events.next({ data: UserResponseDto.fromEntity(entity) });
+		try {
+			const entity = UserEntity.create(data); // Validate the data
+			this.events.next({ data: UserResponseDto.create(entity) });
+		} catch (err) {
+			this.logger.error(`Failed to emit entity.`, err);
+		}
 	}
 
 	/**

--- a/src/application/services/user/UserService.unit.test.ts
+++ b/src/application/services/user/UserService.unit.test.ts
@@ -13,7 +13,7 @@ import { UpdateUserDto } from '../../../http_api/dtos/user/UpdateUserDto';
 import { ISseMessage } from '../../../application/events/ISseMessage';
 import { AbstractService } from '../AbstractService';
 import { WinstonAdapter } from '../../../infrastructure/logging/adapters/WinstonAdapter';
-import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/dto/MockUserDto';
+import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/mocks/dto/MockUserDto';
 import { MockUserEntity } from '../../../__tests__/mocks/entity/MockUserEntity';
 
 describe('UserService Unit', () => {
@@ -150,13 +150,13 @@ describe('UserService Unit', () => {
 
 	// --------------------------------------------------
 
-	it('Can emit an event', () => {
-		const events = service['events'] as Subject<ISseMessage<UserResponseDto>>;
+	it('Can emit an event', async () => {
+		const events = service['events'];
 		const spy = jest.spyOn(events, 'next');
 
-		service.emit(mockedResponse);
+		await service.emit(mockedResponse);
 
-		expect(spy).toHaveBeenCalledWith({ data: UserResponseDto.fromEntity(mockedResponse) });
+		expect(spy).toHaveBeenCalledWith({ data: UserResponseDto.create(mockedResponse) });
 		expect(mockILogger.info).toHaveBeenCalledWith(`Emitting entity by id: ${mockedResponse.id}`);
 	});
 });

--- a/src/application/services/user/UserService.unit.test.ts
+++ b/src/application/services/user/UserService.unit.test.ts
@@ -1,7 +1,6 @@
 import { EntityManager } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Subject } from 'rxjs';
 import { UserService } from './UserService';
 import { UserEntity } from '../../../domain/user/UserEntity';
 import { CreateUserDto } from '../../../http_api/dtos/user/CreateUserDto';
@@ -10,7 +9,6 @@ import { UserResponseDto } from '../../../http_api/dtos/user/UserResponseDto';
 import { MockEntityManager } from '../../../__tests__/mocks/entity_manager/MockEntityManager';
 import { MockRepository } from '../../../__tests__/mocks/repository/MockRepository';
 import { UpdateUserDto } from '../../../http_api/dtos/user/UpdateUserDto';
-import { ISseMessage } from '../../../application/events/ISseMessage';
 import { AbstractService } from '../AbstractService';
 import { WinstonAdapter } from '../../../infrastructure/logging/adapters/WinstonAdapter';
 import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/mocks/dto/MockUserDto';

--- a/src/domain/user/UserEntity.ts
+++ b/src/domain/user/UserEntity.ts
@@ -7,7 +7,8 @@ import { UpdateUserDto } from '../../http_api/dtos/user/UpdateUserDto';
 
 /**
  * Represents a user entity in the database.
- * @column username TEXT NOT NULL UNIQUE
+ * @Column username TEXT NOT NULL UNIQUE
+ * @Column password TEXT NOT NULL
  */
 @Entity()
 export class UserEntity extends AbstractEntity {

--- a/src/domain/user/UserEntity.unit.test.ts
+++ b/src/domain/user/UserEntity.unit.test.ts
@@ -1,4 +1,4 @@
-import { MockUpdateUserDto } from '../../__tests__/dto/MockUserDto';
+import { MockUpdateUserDto } from '../../__tests__/mocks/dto/MockUserDto';
 import { MockUserEntity } from '../../__tests__/mocks/entity/MockUserEntity';
 import { UserEntity } from './UserEntity';
 

--- a/src/http_api/controllers/users/UserController.integration.test.ts
+++ b/src/http_api/controllers/users/UserController.integration.test.ts
@@ -10,7 +10,7 @@ import { GuardedController } from '../GuardedController';
 import { createMockAppModule } from '../../../__tests__/mocks/module/createMockAppModule';
 import { UserModule } from '../../../http_api/modules/users/UserModule';
 import { MockUserEntity } from '../../../__tests__/mocks/entity/MockUserEntity';
-import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/dto/MockUserDto';
+import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/mocks/dto/MockUserDto';
 
 describe('UserController Integration', () => {
 	const TEST_NAME = 'UserController_Integration'; // Value to change
@@ -74,7 +74,7 @@ describe('UserController Integration', () => {
 
 	describe('FIND ALL', () => {
 		it('Finds all entities', async () => {
-			await expect(controller.findAll()).resolves.toEqual([UserResponseDto.fromEntity(entity)]); // Value to change
+			await expect(controller.findAll()).resolves.toEqual([UserResponseDto.create(entity)]); // Value to change
 			await expect(wasLogged(TEST_NAME, `${className}: Finding all entities`)).resolves.toBe(true);
 		});
 
@@ -97,10 +97,10 @@ describe('UserController Integration', () => {
 
 	describe('FIND ONE', () => {
 		it('Finds an entity by id', async () => {
-			const response = UserResponseDto.fromEntity(entity); // Value to change
+			const response = UserResponseDto.create(entity); // Value to change
 
 			await expect(controller.findOne(entity.id)).resolves.toEqual(response);
-			await expect(wasLogged(TEST_NAME, `${className}: Finding entity by id 1`)).resolves.toBe(true);
+			await expect(wasLogged(TEST_NAME, `${className}: Finding entity by id ${entity.id}`)).resolves.toBe(true);
 		});
 
 		// --------------------------------------------------
@@ -123,7 +123,7 @@ describe('UserController Integration', () => {
 
 	describe('UPDATE', () => {
 		it('Updates an entity', async () => {
-			const response = UserResponseDto.fromEntity(entity.update(updateDto)); // Value to change
+			const response = UserResponseDto.create(entity.update(updateDto)); // Value to change
 
 			await expect(controller.update(entity.id, updateDto)).resolves.toEqual(response);
 			await expect(wasLogged(TEST_NAME, `${className}: Updating entity by id ${entity.id}`)).resolves.toBe(true);

--- a/src/http_api/controllers/users/UserController.unit.test.ts
+++ b/src/http_api/controllers/users/UserController.unit.test.ts
@@ -6,7 +6,7 @@ import { mockILogger } from '../../../__tests__/mocks/mockLogAdapter';
 import { UserResponseDto } from '../../dtos/user/UserResponseDto';
 import { GuardedController } from '../GuardedController';
 import { WinstonAdapter } from '../../../infrastructure/logging/adapters/WinstonAdapter';
-import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/dto/MockUserDto';
+import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/mocks/dto/MockUserDto';
 import { MockUserEntity } from '../../../__tests__/mocks/entity/MockUserEntity';
 
 describe('UserController Unit', () => {
@@ -16,7 +16,7 @@ describe('UserController Unit', () => {
 	let mockedResponse: UserResponseDto; // Value to change
 
 	beforeEach(async () => {
-		mockedResponse = new UserResponseDto(MockUserEntity.get());
+		mockedResponse = UserResponseDto.create(MockUserEntity.get());
 
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [UserController], // Value to change

--- a/src/http_api/dtos/ResponseDto.ts
+++ b/src/http_api/dtos/ResponseDto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UUID } from 'crypto';
-import { AbstractEntity } from '../../domain/AbstractEntity'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { AbstractEntity } from '../../domain/AbstractEntity';
+import { NotImplementedException } from '@nestjs/common';
 
 /**
  * ResponseDto represents the standardized API response object for returning an {@link AbstractEntity} to the client.
@@ -30,5 +31,14 @@ export class ResponseDto {
 		this.id = entity.id;
 		this.uuid = entity.uuid;
 		this.createdAt = entity.createdAt;
+	}
+
+	/**
+	 * A static factory to create a Reponse DTO.
+	 * @param entity The entity to create this entity from.
+	 * @returns The created DTO to return to the client.
+	 */
+	public static create(_: AbstractEntity): ResponseDto {
+		throw new NotImplementedException(`${this.constructor.name}: Static 'create' factory not implemented.`);
 	}
 }

--- a/src/http_api/dtos/user/CreateUserDto.ts
+++ b/src/http_api/dtos/user/CreateUserDto.ts
@@ -7,7 +7,8 @@ import { userConstants } from '../../../common/constants/userConstants';
  * This class is responsible for receiving data from a client to create a {@link UserEntity}.
  * It provides Swagger documentation for the API.
  * It JSON validates the following fields:
- * - username: string, at least 3 characters long.
+ * - username: string between 3 and 50 characters
+ * - password: string minimum 8 characters
  */
 export class CreateUserDto extends CreateDto {
 	@ApiProperty({ description: 'The unique username of the user entity', uniqueItems: true, required: true })

--- a/src/http_api/dtos/user/UpdateUserDto.ts
+++ b/src/http_api/dtos/user/UpdateUserDto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MaxLength, MinLength } from 'class-validator';
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 import { UpdateDto } from '../UpdateDto';
 import { userConstants } from '../../../common/constants/userConstants';
 
@@ -7,16 +7,19 @@ import { userConstants } from '../../../common/constants/userConstants';
  * This class is responsible for receiving data from a client to update a {@link UserEntity}.
  * It provides Swagger documentation for the API.
  * It JSON validates the following fields:
- * - username: string, at least 3 characters long.
+ * - username: string between 3 and 50 characters
+ * - password: string minimum 8 characters
  */
 export class UpdateUserDto extends UpdateDto {
 	@ApiProperty({ description: 'The unique username of the user entity', uniqueItems: true, required: true })
+	@IsOptional()
 	@IsString({ message: 'value must be a string' })
 	@MinLength(userConstants.minUsernameLength, { message: `Username must be at least ${userConstants.minUsernameLength} characters long` })
 	@MaxLength(userConstants.maxUsernameLength, { message: `Username can be at most ${userConstants.maxUsernameLength} characters long` })
 	username: string;
 
 	@ApiProperty({ description: 'The password of the user entity', required: true })
+	@IsOptional()
 	@IsString({ message: 'value must be a string' })
 	@MinLength(userConstants.minPasswordLength, { message: `Password must be at least ${userConstants.minPasswordLength} characters long` })
 	password: string;

--- a/src/http_api/dtos/user/UserDto.test.ts
+++ b/src/http_api/dtos/user/UserDto.test.ts
@@ -2,22 +2,19 @@ import { validate } from 'class-validator';
 import { UserEntity } from '../../../domain/user/UserEntity';
 import { UpdateUserDto } from './UpdateUserDto';
 import { UserResponseDto } from './UserResponseDto';
-import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/dto/MockUserDto';
+import { MockCreateUserDto, MockUpdateUserDto } from '../../../__tests__/mocks/dto/MockUserDto';
 import { MockUserEntity } from '../../../__tests__/mocks/entity/MockUserEntity';
 import { CreateUserDto } from './CreateUserDto';
 import { userConstants } from '../../../common/constants/userConstants';
+import { falsyValues } from '../../../__tests__/helpers/falsyValues';
 
 describe("User DTO's", () => {
 	let createDto: CreateUserDto;
 	let updateDto: UpdateUserDto;
 
-	let badValues: unknown[];
-
 	beforeEach(() => {
 		createDto = MockCreateUserDto.get();
 		updateDto = MockUpdateUserDto.get();
-
-		badValues = [null, undefined, '', 0, -100, true, false, [], {}, Symbol('')];
 	});
 
 	describe('Create DTO', () => {
@@ -33,10 +30,7 @@ describe("User DTO's", () => {
 		// --------------------------------------------------
 
 		it('Username must be a string adhering to min/max lengths', async () => {
-			badValues.push('a'.repeat(userConstants.minUsernameLength - 1));
-			badValues.push('b'.repeat(userConstants.maxUsernameLength + 1));
-
-			for (const value of badValues) {
+			for (const value of falsyValues()) {
 				// @ts-expect-error: expects a string.
 				createDto.username = value;
 
@@ -48,9 +42,7 @@ describe("User DTO's", () => {
 		// --------------------------------------------------
 
 		it('Password must be a string adhering to min length', async () => {
-			badValues.push('a'.repeat(userConstants.minPasswordLength - 1));
-
-			for (const value of badValues) {
+			for (const value of falsyValues(userConstants.minPasswordLength)) {
 				// @ts-expect-error: expects a string.
 				createDto.password = value;
 
@@ -77,10 +69,7 @@ describe("User DTO's", () => {
 		// --------------------------------------------------
 
 		it('Username must be a string adhering to min/max length', async () => {
-			badValues.push('a'.repeat(userConstants.minUsernameLength - 1));
-			badValues.push('b'.repeat(userConstants.maxUsernameLength + 1));
-
-			for (const value of badValues) {
+			for (const value of falsyValues(userConstants.minUsernameLength, userConstants.maxUsernameLength, true)) {
 				// @ts-expect-error: Username expects a string.
 				updateDto.username = value;
 
@@ -92,9 +81,7 @@ describe("User DTO's", () => {
 		// --------------------------------------------------
 
 		it('Password must be a string adhering to min length', async () => {
-			badValues.push('a'.repeat(userConstants.minPasswordLength - 1));
-
-			for (const value of badValues) {
+			for (const value of falsyValues(userConstants.minPasswordLength, null, true)) {
 				// @ts-expect-error: Username expects a string.
 				updateDto.password = value;
 
@@ -109,7 +96,7 @@ describe("User DTO's", () => {
 	describe('Response DTO', () => {
 		it('Can be created from the entity', async () => {
 			const entity = MockUserEntity.get();
-			const dto = new UserResponseDto(entity);
+			const dto = UserResponseDto.create(entity);
 
 			expect(dto.id).toEqual(entity.id);
 			expect(dto.uuid).toEqual(entity.uuid);

--- a/src/http_api/dtos/user/UserResponseDto.ts
+++ b/src/http_api/dtos/user/UserResponseDto.ts
@@ -5,8 +5,6 @@ import { ResponseDto } from '../ResponseDto';
 /**
  * This class is responsible for returning a {@link UserEntity} to the client.
  * It provides Swagger documentation for the API.
- * It JSON validates the following fields:
- * - username: string, at least 3 characters long.
  */
 export class UserResponseDto extends ResponseDto {
 	@ApiProperty({ description: 'The unique username of the user entity', uniqueItems: true, required: true })
@@ -21,7 +19,10 @@ export class UserResponseDto extends ResponseDto {
 		this.password = entity.password;
 	}
 
-	static fromEntity(entity: UserEntity): UserResponseDto {
+	/**
+	 *
+	 */
+	static create(entity: UserEntity): UserResponseDto {
 		return new UserResponseDto(entity);
 	}
 }

--- a/src/http_api/modules/users/UserModule.ts
+++ b/src/http_api/modules/users/UserModule.ts
@@ -1,14 +1,13 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { UserEntity } from '../../../domain/user/UserEntity';
 import { UserController } from '../../controllers/users/UserController';
 import { UserService } from '../../../application/services/user/UserService';
 import { UserSubscriber } from '../../../application/events/users/UserSubscriber';
+import { TypeOrmEntityModule } from '../../../infrastructure/database/TypeOrmEntityModule';
 
 /* Remember to add the module to the imports array in src/AppModule.ts */
 
 @Module({
-	imports: [TypeOrmModule.forFeature([UserEntity])],
+	imports: [TypeOrmEntityModule],
 	controllers: [UserController],
 	providers: [UserService, UserSubscriber],
 })

--- a/src/infrastructure/configuration/schemas/loggingSchema.ts
+++ b/src/infrastructure/configuration/schemas/loggingSchema.ts
@@ -56,6 +56,7 @@ export const loggingSchema = Joi.object({
 	console: Joi.boolean().required(),
 	file: loggerFileConfigSchema.required(),
 	http: loggerHTTPConfigSchema.required(),
+	database: Joi.boolean().optional(),
 	useWhitelist: Joi.boolean().required(),
 	prefixWhitelist: Joi.array().items(Joi.string()).required(),
 }).required();

--- a/src/infrastructure/configuration/serverConfig.ts
+++ b/src/infrastructure/configuration/serverConfig.ts
@@ -30,6 +30,7 @@ const defaultConfig: IServerConfig = {
 		http: {
 			enabled: false,
 		},
+		database: false,
 		useWhitelist: false,
 		prefixWhitelist: [],
 	},

--- a/src/infrastructure/database/DatabaseModule.ts
+++ b/src/infrastructure/database/DatabaseModule.ts
@@ -11,6 +11,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 			inject: [ConfigService],
 			useFactory: (configService: ConfigService<IServerConfig>) => {
 				const databaseConfig = configService.get<IServerConfig['database']>('database');
+				const loggingConfig = configService.get<IServerConfig['logging']>('logging');
 
 				return {
 					type: databaseConfig.driver,
@@ -21,9 +22,10 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 					password: databaseConfig.driver !== 'sqlite' ? databaseConfig.password : undefined,
 					synchronize: databaseConfig.synchronize,
 					autoLoadEntities: true,
+					logging: loggingConfig.database,
 				};
 			},
 		}),
 	],
 })
-export class DatabaseModule {} // TODO: Add support for Postgres & MariaDB
+export class DatabaseModule {} // TODO: Add support for Postgres & MariaDBz

--- a/src/infrastructure/database/TypeOrmEntityModule.ts
+++ b/src/infrastructure/database/TypeOrmEntityModule.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserEntity } from '../../domain/user/UserEntity';
+
+@Module({
+	imports: [TypeOrmModule.forFeature([UserEntity])],
+	exports: [TypeOrmModule],
+})
+export class TypeOrmEntityModule {}

--- a/src/infrastructure/logging/ILoggerConfig.ts
+++ b/src/infrastructure/logging/ILoggerConfig.ts
@@ -66,6 +66,7 @@ export interface ILoggerConfig {
 	console: boolean;
 	file: TLoggerFileConfig;
 	http: TLoggerHTTPConfig;
+	database: boolean;
 	useWhitelist: boolean;
 	prefixWhitelist: string[];
 }

--- a/src/infrastructure/logging/adapters/WinstonAdapter.integration.test.ts
+++ b/src/infrastructure/logging/adapters/WinstonAdapter.integration.test.ts
@@ -26,6 +26,7 @@ const CONFIG_TEXT: ILoggerConfig = {
 	http: {
 		enabled: false,
 	},
+	database: false,
 	useWhitelist: false,
 	prefixWhitelist: [],
 };

--- a/src/infrastructure/logging/adapters/WinstonAdapter.test.ts
+++ b/src/infrastructure/logging/adapters/WinstonAdapter.test.ts
@@ -43,6 +43,7 @@ const CONFIG: ILoggerConfig = {
 	http: {
 		enabled: false,
 	},
+	database: false,
 	useWhitelist: true,
 	prefixWhitelist: [
 		'VerboseContext',

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,8 +9,8 @@ import { WinstonAdapter } from './infrastructure/logging/adapters/WinstonAdapter
 import { serverConfig } from './infrastructure/configuration/serverConfig';
 
 async function bootstrap() {
-    // TODO's:
-    /*
+	// TODO's:
+	/*
         Implement Database Migrations
         Create middlewares for:
         - Rate limiting
@@ -30,60 +30,60 @@ async function bootstrap() {
         Mermaid document architecture & API data flow
     */
 
-    // !!! IF ANY CHANGES ARE MADE HERE !!!
-    // Please update the createMockAppModule file in the /src/__tests__/mocks/module directory.
+	// !!! IF ANY CHANGES ARE MADE HERE !!!
+	// Please update the createMockAppModule file in the /src/__tests__/mocks/module directory.
 
-    const app = await NestFactory.create(AppModule, {
-        bufferLogs: true,
-    });
+	const app = await NestFactory.create(AppModule, {
+		bufferLogs: true,
+	});
 
-    // const logger = app.get(NestLogger); // Retrieve the custom logger from Nest's DI container
-    const logger = app.get(WinstonAdapter); // Retrieve the custom logger from Nest's DI container
-    app.useLogger(logger); // Set the custom logger for the entire application
+	// const logger = app.get(NestLogger); // Retrieve the custom logger from Nest's DI container
+	const logger = app.get(WinstonAdapter); // Retrieve the custom logger from Nest's DI container
+	app.useLogger(logger); // Set the custom logger for the entire application
 
-    // Apply global filters to ensure we catch any uncaught errors.
-    app.useGlobalFilters(new HttpErrorFilter(logger));
+	// Apply global filters to ensure we catch any uncaught errors.
+	app.useGlobalFilters(new HttpErrorFilter(logger));
 
-    // Apply global validation pipes (JSON validation)
-    app.useGlobalPipes(
-        new ValidationPipe({
-            whitelist: true, // Strips away any properties that do not have a corresponding DTO property
-            exceptionFactory: (errors: ValidationError[]) => {
-                return new BadRequestException(`DTO validation failed: ${errors.map((error) => error.toString()).join(', ')}`);
-            },
-        }),
-    );
+	// Apply global validation pipes (JSON validation)
+	app.useGlobalPipes(
+		new ValidationPipe({
+			whitelist: true, // Strips away any properties that do not have a corresponding DTO property
+			exceptionFactory: (errors: ValidationError[]) => {
+				return new BadRequestException(`DTO validation failed: ${errors.map((error) => error.toString()).join(', ')}`);
+			},
+		}),
+	);
 
-    app.enableCors(serverConfig().security.cors);
+	app.enableCors(serverConfig().security.cors);
 
-    // Enable API versioning
-    app.enableVersioning({
-        type: VersioningType.URI, // Use URI versioning type
-        defaultVersion: '1', // Set the default version to '1'
-        // Use the @Version decorator to specify the version of the controller or endpoint.
-    });
+	// Enable API versioning
+	app.enableVersioning({
+		type: VersioningType.URI, // Use URI versioning type
+		defaultVersion: '1', // Set the default version to '1'
+		// Use the @Version decorator to specify the version of the controller or endpoint.
+	});
 
-    const swaggerConfig = new DocumentBuilder() // By default located at http://localhost:3000/api
-        .setTitle('NestJS Template API')
-        .setDescription('The NestJS template API Swagger documentation')
-        .setVersion('1.0')
-        // .addBearerAuth() // TODO
-        // .addCookieAuth('jwt', {
-        //     type: 'http',
-        //     in: 'Header',
-        //     scheme: 'Bearer'
-        // })
-        .build();
-    const document = SwaggerModule.createDocument(app, swaggerConfig);
-    SwaggerModule.setup('api', app, document, {
-        swaggerOptions: {
-            requestInterceptor: (req: any) => {
-                req.credentials = 'include';
-                return req;
-            },
-        },
-    });
+	const swaggerConfig = new DocumentBuilder() // By default located at http://localhost:3000/api
+		.setTitle('NestJS Template API')
+		.setDescription('The NestJS template API Swagger documentation')
+		.setVersion('1.0')
+		// .addBearerAuth() // TODO
+		// .addCookieAuth('jwt', {
+		//     type: 'http',
+		//     in: 'Header',
+		//     scheme: 'Bearer'
+		// })
+		.build();
+	const document = SwaggerModule.createDocument(app, swaggerConfig);
+	SwaggerModule.setup('api', app, document, {
+		swaggerOptions: {
+			requestInterceptor: (req: any) => {
+				req.credentials = 'include';
+				return req;
+			},
+		},
+	});
 
-    await app.listen(process.env.NEST_PORT || 3069); // Config object?
+	await app.listen(process.env.NEST_PORT || 3069); // Config object?
 }
 bootstrap();


### PR DESCRIPTION
Database logging in config

Adjusted ResponseDto to also use a static `create` factory in line with Entities.

Catching Service's emit error as it could cause a server crash.

Capturing null values in AbstractEntity's constructor - undefined is still not possible as it's used by TypeORM to create the DB schema.
Improved child's JSON schema validation.
Improved JSON schema error messages.

Added IsOptional decorator to UpdateUserDto's values to allow clients to send partial updates.

Created a TypeORM module to collect and export all the application's entities.

Test improvements